### PR TITLE
RDKCOM-5353: RDKBDEV-3206: drop calls to obsolete isBlocklisted() API

### DIFF
--- a/source/FwUpgradeManager/ssp_main.c
+++ b/source/FwUpgradeManager/ssp_main.c
@@ -241,21 +241,13 @@ int main(int argc, char* argv[])
 #ifdef FEATURE_RDKB_LED_MANAGER
     sysevent_fd =  sysevent_open(SYS_IP_ADDR, SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "fw_upgrade", &sysevent_token);
 #endif
-    bool blocklist_ret = false;
-    blocklist_ret = isBlocklisted();
-    if(blocklist_ret)
-    {
-        CcspTraceInfo(("NonRoot feature is disabled\n"));
-    }
-    else
-    {
-        CcspTraceInfo(("NonRoot feature is enabled, dropping root privileges for RdkInterDeviceManager Process\n"));
-        init_capability();
-        drop_root_caps(&appcaps);
-        update_process_caps(&appcaps);
-        read_capability(&appcaps);
-        clear_caps(&appcaps);
-    }
+
+    CcspTraceInfo(("Dropping root privileges for RdkInterDeviceManager Process\n"));
+    init_capability();
+    drop_root_caps(&appcaps);
+    update_process_caps(&appcaps);
+    read_capability(&appcaps);
+    clear_caps(&appcaps);
 
     for(idx = 1; idx < argc; idx++)
     {


### PR DESCRIPTION
Reason for change:
drop calls to obsolete isBlocklisted() API
Test Procedure: Sanity.
Risks:None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: I82d1388239e1c8717987228ff0348a4c0c284b1f (cherry picked from commit 58f99bc074f3fc7387a85e3de3ce79c23514bae1)